### PR TITLE
调节移动端tap灵敏度

### DIFF
--- a/vue-tap.js
+++ b/vue-tap.js
@@ -38,7 +38,7 @@
       return false;
     }
     var tapObj = self.tapObj;
-    return self.time < 300 && Math.abs(tapObj.distanceX) < 2 && Math.abs(tapObj.distanceY) < 2;
+    return self.time < 300 && Math.abs(tapObj.distanceX) < 10 && Math.abs(tapObj.distanceY) < 10;
   }
 
   function touchstart(e, self) {

--- a/vue-tap.js
+++ b/vue-tap.js
@@ -38,7 +38,7 @@
       return false;
     }
     var tapObj = self.tapObj;
-    return self.time < 300 && Math.abs(tapObj.distanceX) < 20 && Math.abs(tapObj.distanceY) < 20;
+    return self.time < 300 && Math.abs(tapObj.distanceX) < 2 && Math.abs(tapObj.distanceY) < 2;
   }
 
   function touchstart(e, self) {


### PR DESCRIPTION
之前的20的阈值，有点太大了，短暂的滑动会触发点击事件，让用户产生很多误操作。