### PR TITLE
fix: 修复vue1版本中父级DOM里含有input, textarea，无法聚焦的bug

### DIFF
--- a/vue-tap.js
+++ b/vue-tap.js
@@ -80,6 +80,12 @@
         if (self.el.href && !self.modifiers.prevent) {
           return window.location = self.el.href;
         }
+
+        var tagName = e.target.tagName.toLocaleLowerCase();
+        if(tagName === 'input' || tagName === 'textarea') {
+          return e.target.focus();
+        }
+
         fn.call(self, e);
       };
       if (isPc()) {
@@ -126,11 +132,11 @@
       el.tapObj = {};
       el.handler = function (e,isPc) { //This directive.handler
         var value = binding.value;
-        
+
         if (!value && el.href && !binding.modifiers.prevent) {
           return window.location = el.href;
         }
-        
+
         value.event = e;
         var tagName = value.event.target.tagName.toLocaleLowerCase();
         !isPc ? value.tapObj = el.tapObj : null;
@@ -138,7 +144,7 @@
         if(tagName === 'input' || tagName === 'textarea') {
           return value.event.target.focus();
         }
-        
+
         value.methods.call(this, value);
       };
       if (isPc()) {


### PR DESCRIPTION
我们项目由于历史原因还是用的vue1.x的版本，所以修复了vue1版本中父级DOM里含有input, textarea，无法聚焦的bug，麻烦大侠看一下这个PR。

PS: 我用`npm i v-tap`安装的模块的代码和该项目的master代码不一致，主要就是体现如下，希望大侠能够同步更新npm代码，谢谢！

master分支代码如下：

```
if(tagName === 'input' || tagName === 'textarea') {
  return value.event.target.focus();
}
```

npm安装的模块代码如下：

```
if(tagName === 'input') {
  return value.event.target.focus();
}
```
